### PR TITLE
Add terminalFocus (and generalize name?)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "appdev-keybindings",
-  "displayName": "AppDev Keybindings",
-  "description": "Adds consistent keybindings for AppDev students in VSCode.",
+  "name": "terminal-clear",
+  "displayName": "Terminal Clear",
+  "description": "Adds consistent ctrl+k keybinding to clear the terminal.",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.95.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "terminal-clear",
-  "displayName": "terminal-clear",
-  "description": "clears terminal",
+  "name": "appdev-keybindings",
+  "displayName": "AppDev Keybindings",
+  "description": "Adds consistent keybindings for AppDev students in VSCode.",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.95.0"
@@ -13,7 +13,8 @@
     "keybindings": [
       {
         "key": "ctrl+k",
-        "command": "workbench.action.terminal.clear"
+        "command": "workbench.action.terminal.clear",
+        "when": "terminalFocus"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
       {
         "key": "ctrl+k",
         "command": "workbench.action.terminal.clear",
-        "when": "terminalFocus"
+        "when": "terminalFocus && terminalHasBeenCreated && !accessibilityModeEnabled || terminalFocus && terminalProcessSupported && !accessibilityModeEnabled || accessibilityModeEnabled && accessibleViewIsShown && terminalHasBeenCreated && accessibleViewCurrentProviderId == 'terminal' || accessibilityModeEnabled && accessibleViewIsShown && terminalProcessSupported && accessibleViewCurrentProviderId == 'terminal'"
       }
     ]
   }


### PR DESCRIPTION
I'm working my way through the content revisions, and this one is next up since students are about to start engaging a lot with the terminal and server log.

I tested these changes locally and they work (simply opening this folder in VSCode and then pressing `F5` on my keyboard opens a new VSCode window with the extension installed; very easy testing!)

If we can get this uploaded to the Extensions library, then I can put it in all of our repos with project-syncing.

Some notes left in the code. 

After this is merged, and before we upload, I think this repo should be transferred to the `github.com/firstdraft` org